### PR TITLE
Adjust tests to YAML-LibYAML-0.81

### DIFF
--- a/test/compile.t
+++ b/test/compile.t
@@ -39,6 +39,7 @@ test('testml/semicolons.tml', 'TestML1::Compiler::Lite');
 sub test {
     my ($file, $compiler) = @_;
     (my $filename = $file) =~ s!(.*)/!!;
+    local $YAML::XS::LoadBlessed = 1;
     my $runtime = TestML1::Runtime->new(base => "$t/$1");
     my $testml = $runtime->read_testml_file($filename);
     my $ast1 = $compiler->new->compile($testml);


### PR DESCRIPTION
YAML-LibYAML-0.81 sets $YAML::XS::LoadBlessed to false to make the
YAML parser more secure. That breaks t/compile.t test that then
misses Perl class names in the YAML tree:

    not ok 16 - semicolons.tml - TestML1::Compiler::Lite
    #   Failed test 'semicolons.tml - TestML1::Compiler::Lite'
    #   at t/compile.t line 50.
    # +---+------------------------------------------+---+--------------------+
    # | Ln|Got                                       | Ln|Expected            |
    # +---+------------------------------------------+---+--------------------+
    # *  1|'--- !!perl/hash:TestML1::Function        *  1|'---                *
    # |  2|namespace:                                |  2|namespace:          |
    # *  3|  TestML: !!perl/hash:TestML1::Str        *  3|  TestML:           *
    # |  4|    value: 0.1.0                          |  4|    value: 0.1.0    |

This patch sets the $YAML::XS::LoadBlessed switch back to true in the
tests. A future-friendly fix should probably regenerate the testing
YAML files and disable $YAML::XS::LoadBlessed explictly.

<https://github.com/ingydotnet/testml1-pm/issues/1>